### PR TITLE
Support recursive jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,13 +28,13 @@ deps = pyflakes
 commands = pyflakes jenkins_jobs tests setup.py
 
 [testenv:compare-xml-config]
-commands = jenkins-jobs {posargs:test -o .test/run-conf/default/out/ .test/run-conf/config/}
+commands = jenkins-jobs {posargs:test -o .test/run-conf/default/out/ -r .test/run-conf/config/}
 
 [testenv:compare-xml-old]
-commands = jenkins-jobs test -o .test/old/out/ .test/old/config/
+commands = jenkins-jobs test -o .test/old/out/ -r .test/old/config/
 
 [testenv:compare-xml-new]
-commands = jenkins-jobs test -o .test/new/out/ .test/new/config/
+commands = jenkins-jobs test -o .test/new/out/ -r .test/new/config/
 
 [testenv:docs]
 commands = python setup.py build_sphinx {posargs}


### PR DESCRIPTION
Sometimes jobs can be stored in hierarchy directories, and that will be
easier to maintain different projects' jobs together.

Signed-off-by: Julien <julienjut@gmail.com>